### PR TITLE
Trailing whitespace added to text of elements with namespaces

### DIFF
--- a/vkbeautify.js
+++ b/vkbeautify.js
@@ -95,7 +95,7 @@ vkbeautify.prototype.xml = function(text,step) {
 		str = '',
 		ix = 0,
 		shift = step ? createShiftArr(step) : this.shift,
-		withNamespace = false;
+		withNamespace = 0;
 
 		for(ix=0;ix<len;ix++) {
 			// start comment or <![CDATA[...]]> or <!DOCTYPE //
@@ -130,11 +130,12 @@ vkbeautify.prototype.xml = function(text,step) {
 			if(ar[ix].search(/<\//) > -1) { 
 				--deep;
 				str = !inComment && !withNamespace? str += shift[deep] + ar[ix] : str += ar[ix];
-				withNamespace = false;
 			} else 
 			// <elm/> //
 			if(ar[ix].search(/\/>/) > -1 ) { 
 				str = !inComment ? str += shift[deep]+ar[ix] : str += ar[ix];
+				if (ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1)
+			        deep--;
 			} else 
 			// <? xml ... ?> //
 			if(ar[ix].search(/<\?/) > -1) { 
@@ -143,12 +144,14 @@ vkbeautify.prototype.xml = function(text,step) {
 			// xmlns //
 			if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) { 
 				str += shift[deep]+ar[ix];
-				withNamespace = true;
+				withNamespace = 2;
 			} 
 			
 			else {
 				str += ar[ix];
 			}
+			if (withNamespace)
+				withNamespace--;
 		}
 		
 	return  (str[0] == '\n') ? str.slice(1) : str;

--- a/vkbeautify.js
+++ b/vkbeautify.js
@@ -94,7 +94,8 @@ vkbeautify.prototype.xml = function(text,step) {
 		deep = 0,
 		str = '',
 		ix = 0,
-		shift = step ? createShiftArr(step) : this.shift;
+		shift = step ? createShiftArr(step) : this.shift,
+		withNamespace = false;
 
 		for(ix=0;ix<len;ix++) {
 			// start comment or <![CDATA[...]]> or <!DOCTYPE //
@@ -127,7 +128,9 @@ vkbeautify.prototype.xml = function(text,step) {
 			} else 
 			// </elm> //
 			if(ar[ix].search(/<\//) > -1) { 
-				str = !inComment ? str += shift[--deep]+ar[ix] : str += ar[ix];
+				--deep;
+				str = !inComment && !withNamespace? str += shift[deep] + ar[ix] : str += ar[ix];
+				withNamespace = false;
 			} else 
 			// <elm/> //
 			if(ar[ix].search(/\/>/) > -1 ) { 
@@ -140,6 +143,7 @@ vkbeautify.prototype.xml = function(text,step) {
 			// xmlns //
 			if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) { 
 				str += shift[deep]+ar[ix];
+				withNamespace = true;
 			} 
 			
 			else {


### PR DESCRIPTION
An issue I'm having is that when a tag contains a namespace it causes the closing tag of the element to drop to a new line and indent, which adds additional whitespace into the text.

``` javascript
vkbeautify.xml('<root><child xmlns="ns">Text</child></root>');
```

Produces:

``` xml
<root>
    <child 
        xmlns="ns">Text
    </child>
</root>
```

This pull request prevents that newline and indent from being added to elements when they have namespaces.

``` javascript
<root>
    <child
        xmlns="ns">test</child>
</root>
```

Indentation should still be working correctly for elements nested in elements with namespaces.

``` javascript
vkbeautify.xml('<root><child xmlns="ns"><test></test></child></root>');
```

Produces:

``` xml
<root>
    <child
        xmlns="ns">
        <test></test>
    </child>
</root>
```

And thanks for making this great tool!
