### PR TITLE
Removed window reference in library to enable usage with web workers

### DIFF
--- a/vkbeautify.js
+++ b/vkbeautify.js
@@ -45,7 +45,7 @@
 *
 */
 
-(function() {
+var vkbeautify = (function() {
 
 function createShiftArr(step) {
 
@@ -352,7 +352,9 @@ vkbeautify.prototype.sqlmin = function(text) {
 	return text.replace(/\s{1,}/g," ").replace(/\s{1,}\(/,"(").replace(/\s{1,}\)/,")");
 }
 
-window.vkbeautify = new vkbeautify();
+vkbeautify = new vkbeautify();
+
+return vkbeautify;
 
 })();
 


### PR DESCRIPTION
Just changing the way the library is globally available by removing `window` reference during initialization. My use case required me to offload some text processing to web workers which is a fairly common thing these days wherein large text is processed asynchronously.   By removing the reference to `window`, this library can be used with web workers or any other context that breaks when the `DOM` is referenced.
