### PR TITLE
Define `ix` before using it

### DIFF
--- a/vkbeautify.js
+++ b/vkbeautify.js
@@ -70,7 +70,7 @@ function createShiftArr(step) {
 	}
 
 	var shift = ['\n']; // array of shifts
-	for(ix=0;ix<100;ix++){
+	for(var ix=0;ix<100;ix++){
 		shift.push(shift[ix]+space); 
 	}
 	return shift;


### PR DESCRIPTION
The function `createShiftArr` uses variable `ix` without defining it first. I've had instances where the code crashes when you run under `strict` mode.
