### PR TITLE
Issue with wrong shift fix

### DIFF
--- a/vkbeautify.js
+++ b/vkbeautify.js
@@ -126,6 +126,12 @@ vkbeautify.prototype.xml = function(text,step) {
 			} else 
 			// </elm> //
 			if(ar[ix].search(/<\//) > -1) { 
+				// xmls ... />
+				if(ar[ix-1] &&
+					(ar[ix-1].search(/xmlns\:/) > -1  || ar[ix-1].search(/xmlns\=/) > -1) &&
+					ar[ix-1].search(/\/>/) > -1) {
+					deep--;
+				}
 				str = !inComment ? str += shift[--deep]+ar[ix] : str += ar[ix];
 			} else 
 			// <elm/> //


### PR DESCRIPTION
xml to reproduse:

`<tag1><tag2><tag3><tag4><tag5 xmlns:ns="url"/></tag4></tag3></tag2></tag1>`

`</tag4>` will have incorrect shift

```
<tag1>
    <tag2>
        <tag3>
            <tag4>
                <tag5
                    xmlns:ns="url"/>
                </tag4>
            </tag3>
        </tag2>
    </tag1>
```