### PR TITLE
Removing GPL license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,9 @@ text in **XML**, **JSON**, **CSS** and **SQL** formats.
 
 **Home page:** [http://www.eslinstructor.net/vkbeautify/](http://www.eslinstructor.net/vkbeautify/) 
 
-**License:** Dual licensed under
-the MIT and GPL licenses:
+**License:** Dual licensed under the MIT license:
 
 [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
-[http://www.gnu.org/licenses/gpl.html](http://www.gnu.org/licenses/gpl.html)
 
 
    **Pretty print**


### PR DESCRIPTION
Per this Issue: https://github.com/vkiryukhin/vkBeautify/issues/19 and other MIT notes in the source, I have updated the README to state the licensing is MIT rather than (MIT OR GPL).